### PR TITLE
Bump dependencies and move to 2018-edition Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "asciicast"
 version = "0.2.3-pre"
+edition = "2018"
 authors = ["Christian Legnitto <christian@legnitto.com>"]
 description = "A library for the Asciicast file format used by Asciinema."
 homepage = "https://github.com/LegNeato/asciicast-rs"
@@ -15,8 +16,7 @@ chrono_support = ["chrono"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"], optional = true }
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [package.metadata.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciicast"
-version = "0.2.3-pre"
+version = "0.2.4"
 edition = "2018"
 authors = ["Christian Legnitto <christian@legnitto.com>"]
 description = "A library for the Asciicast file format used by Asciinema."

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,7 +1,7 @@
 extern crate serde;
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 
-use event::EventType;
+use crate::event::EventType;
 use serde::de::{Deserialize, Deserializer, Error as DeserializeError, Visitor};
 use std::fmt;
 
@@ -81,7 +81,7 @@ impl<'de> Visitor<'de> for EntryVisitor {
 #[cfg(test)]
 mod tests {
     use super::Entry;
-    use event::EventType;
+    use crate::event::EventType;
     use serde_json;
 
     #[test]

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,9 +1,8 @@
 extern crate serde;
 
 #[cfg(feature = "chrono")]
-extern crate chrono;
-#[cfg(feature = "chrono")]
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,17 +5,12 @@ pub use entry::*;
 pub use event::*;
 pub use header::*;
 
-#[cfg(feature = "chrono")]
-extern crate chrono;
-
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "UPPERCASE")]
 enum EnvVar {
-    SHELL,
-    TERM,
+    Shell,
+    Term,
     Custom(String),
 }


### PR DESCRIPTION
Just gave the project a very quick once-over to make it compatible with modern Rust.

I'm in the process of fixing up asciinema-rs too, but it depends on this crate. I've bumped the version number too, so I can point asciinema-rs at 0.2.4 as well, if/when this pull request is accepted.